### PR TITLE
Fix proxy display

### DIFF
--- a/src/moulti/ansible/moulti.py
+++ b/src/moulti/ansible/moulti.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 # pylint: disable=import-error
 from ansible.utils.color import parsecolor # type: ignore
-from ansible.utils.display import _proxy, Display # type: ignore
+from ansible.utils.display import Display # type: ignore
 from ansible.plugins.callback.default import CallbackModule as DefaultCallbackModule # type: ignore
 
 DOCUMENTATION = '''
@@ -150,7 +150,7 @@ class MoultiDisplay(Display):
 		pipe.stdin.write(data.encode('utf-8')) # type: ignore
 		pipe.stdin.flush() # type: ignore
 
-	@_proxy
+	@Display._proxy
 	def display(self, msg: str, color: str | None = None, stderr: bool = False, screen_only: bool = False,
 		log_only: bool = False, newline: bool = True,
 	) -> None:

--- a/src/moulti/ansible/moulti.py
+++ b/src/moulti/ansible/moulti.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 # pylint: disable=import-error
 from ansible.utils.color import parsecolor # type: ignore
-from ansible.utils.display import proxy_display, Display # type: ignore
+from ansible.utils.display import _proxy, Display # type: ignore
 from ansible.plugins.callback.default import CallbackModule as DefaultCallbackModule # type: ignore
 
 DOCUMENTATION = '''
@@ -150,7 +150,7 @@ class MoultiDisplay(Display):
 		pipe.stdin.write(data.encode('utf-8')) # type: ignore
 		pipe.stdin.flush() # type: ignore
 
-	@proxy_display
+	@_proxy
 	def display(self, msg: str, color: str | None = None, stderr: bool = False, screen_only: bool = False,
 		log_only: bool = False, newline: bool = True,
 	) -> None:


### PR DESCRIPTION
I think this fixes #7. At the very least, I was able to get it to run. However, I'm guessing that since Ansible moved `proxy_display` under `Display` and renamed it to `_proxy`, it may not be safe to depend on it 🤷 